### PR TITLE
fix(display.c): Specify void

### DIFF
--- a/source/display.c
+++ b/source/display.c
@@ -259,7 +259,7 @@ void exitcurses(void) {
 	fflush(stdout);
 }
 
-void force_window(){
+void force_window(void){
 	switch(input_mode){
 		case INPUT_CHANGE:
 			current_window = &wresult;
@@ -272,7 +272,7 @@ void force_window(){
 	}
 }
 
-static inline void display_help() {
+static inline void display_help(void) {
 	// XXX: this could be optimized by only overriding the buffer if theres an actual
 	// change
 	werase(whelp);
@@ -287,7 +287,7 @@ static inline void display_help() {
 	do_press_any_key = true;
 }
 
-static inline void display_case(){
+static inline void display_case(void){
 	wmove(wcase, 0, 0);
 	wattron(wcase, COLOR_PAIR(COLOR_PAIR_CASE));
 	waddstr(wcase, (caseless ? "Case: OFF" : "Case:  ON"));
@@ -326,7 +326,7 @@ static inline void display_frame(const bool border_only) {
 	wattroff(stdscr, COLOR_PAIR(COLOR_PAIR_FRAME));
 }
 
-static inline void display_mode() {
+static inline void display_mode(void) {
 	werase(wmode);
 
 	for(int i = 0; i < FIELDS; ++i) {
@@ -344,7 +344,7 @@ static inline void display_mode() {
 	}
 }
 
-static inline void display_command_field() {
+static inline void display_command_field(void) {
 	werase(winput);
 	wattron(winput, COLOR_PAIR(COLOR_PAIR_PROMPT));
 	mvwaddstr(winput, 0, 0, prompts[input_mode]);
@@ -354,7 +354,7 @@ static inline void display_command_field() {
 	display_cursor();
 }
 
-static inline void display_results() {
+static inline void display_results(void) {
 	int	  i;
 	char *s;
 	int	  screenline;			/* screen line number */


### PR DESCRIPTION
Empty parameters for a function is undefined behaviour.