### PR TITLE
Refactoring 'findinit' + maybe a bug discovered?

### DIFF
--- a/documentation/BUGS
+++ b/documentation/BUGS
@@ -1,3 +1,11 @@
 > a space is inserted into the end of function head argument lists {`int f(void )`}
 
+> 14th December 2024 (yama):
+> Searching for symbol 'pp' (using 'Find assignments to this symbol' for e.g.)
+>will return search results for symbols named 'p', for example:
+>    `p = malloc(sizeof(*p));`
+>
+> The symbol identifiers we return should match 'pp' exclusively, not
+>substrings.
+
 // No known bugs.

--- a/source/find.c
+++ b/source/find.c
@@ -101,6 +101,9 @@ static char *findinclude(const char *pattern);
 static char *findassign(const char *pattern);
 static char *findallfcns(const char *dummy);
 
+
+static inline void trim_trailing_ws(char *str, size_t len);
+
 typedef char *(*FP)(const char *); /* pointer to function returning a character pointer */
 /* Paralel array to "fields", indexed by "field" */
 FP field_searchers[FIELDS + 1] = {
@@ -670,6 +673,23 @@ char *findinclude(const char *pattern) {
 	return NULL;
 }
 
+static inline
+void trim_trailing_ws(char *str, size_t len) {
+
+	/* Jump to end of string */
+	char *end = str;
+	end += len;
+
+	/* While character is space and not NULL.
+	* Checking for NULL is required otherwise 'isspace' will produce undefined
+	 behaviour when encountering a nonstandard character. */
+	while ((end != NULL) && isspace(end)) {
+		/* Move backwards */
+		--end;
+	}
+	*end = '\0';
+}
+
 /* initialize */
 int findinit(const char *pattern_) {
 
@@ -694,7 +714,7 @@ int findinit(const char *pattern_) {
 	/* Pattern length */
 	size_t pattlen = strlen(pattern);
 
-	/* 04-12-2024 23:27 yama
+	/* 14-12-2024 23:27 yama
 	 * NOTE: It is necessary to check the length because 'pattern' && 'pattern_'
 	   could be non-null while still being 0 length.
 	 */
@@ -702,6 +722,9 @@ int findinit(const char *pattern_) {
 		free(pattern);
 		return NOTSYMBOL;
 	}
+
+	/* Trim trailing whitespace */
+	trim_trailing_ws(pattern, pattlen);
 
 	/* Make sure pattern is lowercased. Curses
 	 * mode gets this right all on its own, but at least -L mode

--- a/source/find.c
+++ b/source/find.c
@@ -103,6 +103,7 @@ static char *findallfcns(const char *dummy);
 
 
 static inline void trim_trailing_ws(char *str, size_t len);
+static inline bool is_valid_c_symbol(char *str);
 
 typedef char *(*FP)(const char *); /* pointer to function returning a character pointer */
 /* Paralel array to "fields", indexed by "field" */
@@ -690,6 +691,23 @@ void trim_trailing_ws(char *str, size_t len) {
 	*end = '\0';
 }
 
+
+static inline
+bool is_valid_c_symbol(char *str) {
+	/* A symbol must start with an underscore or an alpha-numerical char */
+	if ((!isalpha((unsigned char)*str)) && (*str != '_')) {
+		return false;
+	}
+
+	/* Check whole string to ensure it is indeed all alpha and/or underscores */
+	while (*++str != '\0') {
+		if ((!isalpha((unsigned char)*str)) && (*str != '_')) {
+			return false;
+		}
+	}
+	return true;
+}
+
 /* initialize */
 int findinit(const char *pattern_) {
 
@@ -747,16 +765,11 @@ int findinit(const char *pattern_) {
 	} else {
 		/* check for a valid C symbol */
 		s = pattern;
-		if(!isalpha((unsigned char)*s) && *s != '_') {
+		if (!is_valid_c_symbol(s)) {
 			r = NOTSYMBOL;
 			goto end;
 		}
-		while(*++s != '\0') {
-			if(!isalnum((unsigned char)*s) && *s != '_') {
-				r = NOTSYMBOL;
-				goto end;
-			}
-		}
+
 		/* look for use of the -T option (truncate symbol to 8
 		   characters) on a database not built with -T */
 		if(trun_syms == true && preserve_database == true && dbtruncated == false &&

--- a/source/find.c
+++ b/source/find.c
@@ -200,6 +200,11 @@ bool check_for_assignment(void) {
 	return false;
 }
 
+
+/* 14-12-2024 21:24 yama
+ * FIXME If we use the 'find assignments to this symbol' for a search such as 'pp'
+   it will retrieve results of symbols named 'p'
+ */
 /* The actual routine that does the work for findsymbol() and
  * findassign() */
 static

--- a/source/find.c
+++ b/source/find.c
@@ -694,9 +694,13 @@ int findinit(const char *pattern_) {
 	/* Pattern length */
 	size_t pattlen = strlen(pattern);
 
-	/* remove trailing white space */
-	for(s = pattern + (pattlen - 1); isspace((unsigned char)*s); --s) {
-		*s = '\0';
+	/* 04-12-2024 23:27 yama
+	 * NOTE: It is necessary to check the length because 'pattern' && 'pattern_'
+	   could be non-null while still being 0 length.
+	 */
+	if (pattlen == 0) {
+		free(pattern);
+		return NOTSYMBOL;
 	}
 
 	/* Make sure pattern is lowercased. Curses

--- a/source/find.c
+++ b/source/find.c
@@ -705,6 +705,7 @@ int findinit(const char *pattern_) {
 	int			  i;
 	char		 *s;
 	unsigned char c;
+	const unsigned int truncation_len = 8;
 
 	/* HBB: be nice: free regexp before allocating a new one */
 	if(isregexp_valid == true) regfree(&regexp);
@@ -759,8 +760,8 @@ int findinit(const char *pattern_) {
 		/* look for use of the -T option (truncate symbol to 8
 		   characters) on a database not built with -T */
 		if(trun_syms == true && preserve_database == true && dbtruncated == false &&
-			s - pattern >= 8) {
-			strcpy(pattern + 8, ".*");
+			s - pattern >= truncation_len) {
+			strcpy(pattern + truncation_len, ".*");
 			isregexp = true;
 		}
 	}
@@ -780,7 +781,7 @@ int findinit(const char *pattern_) {
 			s[i] = '\0';
 		}
 		/* if requested, try to truncate a C symbol pattern */
-		if(trun_syms == true && strpbrk(s, "[{*+") == NULL) { s[8] = '\0'; }
+		if(trun_syms == true && strpbrk(s, "[{*+") == NULL) { s[truncation_len] = '\0'; }
 		/* must be an exact match */
 		/* note: regcomp doesn't recognize ^*keypad$ as a syntax error
 				 unless it is given as a single arg */
@@ -793,7 +794,7 @@ int findinit(const char *pattern_) {
 		}
 	} else {
 		/* if requested, truncate a C symbol pattern */
-		if(trun_syms == true && field <= CALLING) { pattern[8] = '\0'; }
+		if(trun_syms == true && field <= CALLING) { pattern[truncation_len] = '\0'; }
 		/* compress the string pattern for matching */
 		s = cpattern;
 		for(i = 0; (c = pattern[i]) != '\0'; ++i) {


### PR DESCRIPTION
Good evening, 

I was refactoring `findinit` in `find.c` because it is _too_ large and complex of a function (in my opinion anyways).

A summary of the changes are:
- Extract the code checking for whether a string is a valid `C` symbol/identifier into its own function.
- The code to trim whitespace has been moved into a new function too.
- Replace usage of the magic number for truncated length (`8`) into a named constant (makes it easier to change down the road).
- Ensure the length of text we use as the search pattern is longer than 0 (stops a segmentation fault on my end).

I also think I found a bug so I included some documentation/comments regarding that.

The bug basically boils down to the program returning matches for sub-strings of our search query.
- So searching for `pp` will return symbols with the name `p`